### PR TITLE
fixed fileSystemException while serialized file write on making db

### DIFF
--- a/scripts/serializer.dart
+++ b/scripts/serializer.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
+
 import 'models.dart';
 import 'utils.dart';
 
-void serialize(List<Entry> words, String defFile, String indexFile) {
+void serialize(List<Entry> words, String defFile, String indexFile) async {
   List<List<dynamic>> offsets = [];
 
   int offset = 0;
@@ -18,7 +19,7 @@ void serialize(List<Entry> words, String defFile, String indexFile) {
 
   log("serialized", buffer.length);
 
-  var f = File(defFile);
+  var f = await File(defFile).create(recursive: true);
   f.writeAsBytesSync(buffer, flush: true);
 
   List<int> indexBuffer = [];


### PR DESCRIPTION
fixes
```Unhandled exception:
FileSystemException: Cannot open file, path = '../assets/olam_defs.bin' (OS Error: No such file or directory, errno = 2)
#0      _File.throwIfError (dart:io/file_impl.dart:635:7)
#1      _File.openSync (dart:io/file_impl.dart:479:5)
#2      _File.writeAsBytesSync (dart:io/file_impl.dart:604:31)
#3      serialize (file:///Users/moole/AndroidStudioProjects/ditto/scripts/serializer.dart:22:5)
#4      main (file:///Users/moole/AndroidStudioProjects/ditto/scripts/builder.dart:18:3)
#5      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:301:19)
#6      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
make: *** [db] Error 255
```